### PR TITLE
fix default action validity & validity while robustifying

### DIFF
--- a/craam/State.hpp
+++ b/craam/State.hpp
@@ -48,7 +48,7 @@ public:
     SAState() : actions(0), valid(0) {};
 
     /** Initializes state with actions and sets them all to valid */
-    SAState(const vector<AType>& actions) : actions(actions), valid(actions.size(),true) { };
+    SAState(const vector<AType>& actions) : actions(actions), valid(actions.size(),false) { };
 
     /** Number of actions */
     size_t action_count() const { return actions.size();};
@@ -106,7 +106,7 @@ public:
     Set action validity. A valid action can be used in computations. An 
     invalid action is just a placeholder.
     */
-    void set_valid(long actionid, bool value = true){
+    void set_valid(long actionid, bool value = false){
         assert(actionid < long(valid.size()) && actionid >= 0);
         valid[actionid] = value;
     };

--- a/craam/modeltools.hpp
+++ b/craam/modeltools.hpp
@@ -250,6 +250,8 @@ RMDP robustify(const MDP& mdp, bool allowzeros = false){
         const auto& s = mdp[si];
         auto& newstate = rmdp.create_state(si);
         for(size_t ai : indices(s)){
+            if(!s.is_valid(ai))
+                continue;
             auto& newaction = newstate.create_action(ai);
             const Transition& t = s[ai].get_outcome();
             // iterate over transitions next states (at t+1) and add samples


### PR DESCRIPTION
It has a segmentation fault related to the action validity. It seems this modification fixes the issue.