### PR TITLE
Fix bug

### DIFF
--- a/craam/State.hpp
+++ b/craam/State.hpp
@@ -164,13 +164,13 @@ public:
 
     /** Returns the mean reward following the action (and outcome). */
     prec_t mean_reward(long actionid, numvec nataction) const{
-        if(is_terminal()) return 0;
+        if(is_terminal() || !is_valid(actionid)) return 0;
         else return get_action(actionid).mean_reward(nataction);
     }
 
     /** Returns the mean reward following the action. */
     prec_t mean_reward(long actionid) const{
-        if(is_terminal()) return 0;
+        if(is_terminal() || !is_valid(actionid)) return 0;
         else return get_action(actionid).mean_reward(); 
     }
 


### PR DESCRIPTION
When a state has invalid action, it shouldn't go ahead with that to calculate reward.